### PR TITLE
Fix unhandled exceptions in port-scanner. (eclipse#281)

### DIFF
--- a/plugins/ports-plugin/src/port-scanner.ts
+++ b/plugins/ports-plugin/src/port-scanner.ts
@@ -29,8 +29,12 @@ export class PortScanner {
         const ipConverter = new IpConverter();
         // connect to /proc/net/tcp and /proc/net/tcp6
         const command = new Command(__dirname);
-        const outputv4 = await command.exec(PortScanner.GRAB_PORTS_IPV4);
-        const outputv6 = await command.exec(PortScanner.GRAB_PORTS_IPV6);
+        const outputv4 = await command
+            .exec(PortScanner.GRAB_PORTS_IPV4)
+            .catch(e => { console.error(e); return ''; });
+        const outputv6 = await command
+            .exec(PortScanner.GRAB_PORTS_IPV6)
+            .catch(e => { console.error(e); return ''; });
 
         // assembe ipv4 and ipv6 output
         const output = `


### PR DESCRIPTION
In case IPv6 was disabled, `/proc/net/tcp6` will not exist.
(Probably IPv4 will be similar.)

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
